### PR TITLE
Update executors.py

### DIFF
--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -438,7 +438,7 @@ class MultithreadedJobExecutor(JobExecutor):
         logger: logging.Logger,
         runtime_context: RuntimeContext,
     ) -> None:
-        self.taskqueue: TaskQueue = TaskQueue(threading.Lock(), psutil.cpu_count())
+        self.taskqueue: TaskQueue = TaskQueue(threading.Lock(), self.max_cores )
         try:
             jobiter = process.job(job_order_object, self.output_callback, runtime_context)
 


### PR DESCRIPTION
The class TascQueue accepts an argument `thread_count` that is used for the max size of a queue.

In the `MultithreadedJobExecutor `class there is a variable defined (`max_cores`) that is getting its value from the available cores of the machine. Further down in the same class when TaskQueue is called instead of using the `max_cores` it is using `psutil.cpu_count()`. 

I suggest to use  the self.max_cores in the call of TaskQueue in the file executor.py instead of psutil.cpu_count()

Use case:
when a job executor is setup as MultithreadedJobExecutor one can override the max_cores after the initialization of the object and limit the use to the specified cores.

Additional enhancement would be to include an argument to allow the use to provide the number of cores available for use